### PR TITLE
fixed bug in spreadcore caused by coercion to factor

### DIFF
--- a/R/ts_reshape.R
+++ b/R/ts_reshape.R
@@ -113,7 +113,7 @@ spread_core <- function(x) {
 
   z <- dcast(x, as.formula(paste(time.name, "~", var.name)), value.var = value.name)
   # keep order as in input
-  setcolorder(z, c(time.name, unique(x[[var.name]])))
+  setcolorder(z, c(time.name, unique(as.character(x[[var.name]]))))
   z
 }
 


### PR DESCRIPTION
Used it `ts_ts` on a data.frame (quarterly time series with monthly dates 2010-04-01) and ran into a bug in `spread_core`. setcolorder had problems because of x[[var.name]] returned a factor. After coercion to character my test passed. 