### PR TITLE
avoid date classes not getting respected by stopifnot, fixes #213

### DIFF
--- a/R/date_helpers.R
+++ b/R/date_helpers.R
@@ -24,7 +24,7 @@ as_time_or_date <- function(x) {
 #' @param x Date or POSIXct
 #' @noRd
 regularize_date <- function(x) {
-  stopifnot(class(x)[1] %in% c("POSIXct", "Date"))
+  stopifnot(inherits(x,c("POSIXct", "Date")))
 
   N <- NULL
   freq <- NULL
@@ -81,7 +81,7 @@ regularize_date <- function(x) {
 #' @param x Date or POSIXct
 #' @noRd
 regularize_non_heuristic <- function(x) {
-  stopifnot(class(x)[1] %in% c("POSIXct", "Date"))
+  stopifnot(inherits(x,c("POSIXct", "Date")))
 
   x.num <- as.numeric(x)
   dd <- unique(round(diff(x.num), 5))

--- a/R/date_helpers.R
+++ b/R/date_helpers.R
@@ -24,7 +24,7 @@ as_time_or_date <- function(x) {
 #' @param x Date or POSIXct
 #' @noRd
 regularize_date <- function(x) {
-  stopifnot(inherits(x,c("POSIXct", "Date")))
+  stopifnot(inherits(x, c("POSIXct", "Date")))
 
   N <- NULL
   freq <- NULL
@@ -81,7 +81,7 @@ regularize_date <- function(x) {
 #' @param x Date or POSIXct
 #' @noRd
 regularize_non_heuristic <- function(x) {
-  stopifnot(inherits(x,c("POSIXct", "Date")))
+  stopifnot(inherits(x, c("POSIXct", "Date")))
 
   x.num <- as.numeric(x)
   dd <- unique(round(diff(x.num), 5))


### PR DESCRIPTION
## Description
regularize date helpers used ONLY the first element of the vectore returned by class. Hence if a Date had multiple classes like many advanced date objects have, stopifnot caused an error. data.table adds *iDate* on top of a standard date class while preserving the standard Date class. Because *Date* is only the second element of the class vector, it's not respected, *iDate* is not known and the function crashes despite the fact that the input is a perfectly fine date. 

## Related Issue

fix #213  

## Example

see diff, it's only a small change and the diffs shows exactly what happens. 

